### PR TITLE
Add services landing page with anchor sections

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Timeless Solutions | Services</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
+  <link rel="icon" href="/favicon.png">
+  <style>
+    :root{
+      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+    }
+    *{box-sizing:border-box} body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;
+      color:var(--black);background:var(--off);line-height:1.5}
+    a{color:inherit;text-decoration:none}
+    .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
+    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    nav{display:flex;align-items:center;justify-content:space-between;height:64px}
+    nav .brand{font-weight:700;letter-spacing:.3px}
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
+    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--black)}
+    .hero{padding:80px 0;background:#fff}
+    .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
+    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
+    .section{padding:72px 0}
+    h2{font-size:clamp(24px,3vw,36px);margin:0 0 12px}
+    .muted{color:var(--gray)}
+    .toc{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px}
+    .badge{display:inline-block;background:#fff;border:1px solid #eee;border-radius:999px;padding:10px 16px;font-size:14px}
+    .detail{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:32px;margin-bottom:28px}
+    .detail header{position:static;border:none;padding:0;margin-bottom:18px}
+    .detail h3{margin:0 0 8px;font-size:22px}
+    .detail ul{margin:0 0 18px 18px;padding:0}
+    .detail ul li{margin-bottom:8px}
+    .pill{display:inline-block;background:var(--black);color:#fff;padding:8px 14px;border-radius:999px;font-size:13px;margin-bottom:16px}
+    footer{padding:48px 0;color:#444}
+    @media (max-width:700px){
+      nav{flex-wrap:wrap;gap:12px;height:auto;padding:16px 0}
+      nav ul{flex-wrap:wrap;justify-content:flex-end}
+      .hero{padding:60px 0}
+    }
+  </style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <nav>
+      <a class="brand" href="/HOME.HTML">Timeless Solutions</a>
+      <ul>
+        <li><a href="/HOME.HTML#services">Services Overview</a></li>
+        <li><a href="/HOME.HTML#results">Results</a></li>
+        <li><a href="/HOME.HTML#about">About</a></li>
+        <li><a class="btn primary" href="/HOME.HTML#contact">Book Strategy Call</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="hero">
+    <div class="wrap">
+      <p class="muted">Services</p>
+      <h1>Strategic Systems Built Around Your Growth</h1>
+      <p>Each engagement is designed to eliminate bottlenecks, connect your marketing stack, and deliver the data you need to scale with confidence.</p>
+      <div class="toc">
+        <a class="badge" href="#seo">SEO Optimization</a>
+        <a class="badge" href="#content">Content Marketing</a>
+        <a class="badge" href="#social">Social Media Strategy</a>
+        <a class="badge" href="#paid">Paid Ads (PPC)</a>
+        <a class="badge" href="#crm">CRM &amp; Automation</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="seo">
+    <div class="wrap detail">
+      <span class="pill">SEO Optimization</span>
+      <h2>Show up exactly where your buyers are searching</h2>
+      <p>Technical improvements, on-page optimization, and a content roadmap help you outrank competitors for the keywords that matter.</p>
+      <ul>
+        <li>Comprehensive audits covering site structure, metadata, and Core Web Vitals.</li>
+        <li>Editorial calendars with search intent mapped to every stage of your funnel.</li>
+        <li>Backlink and authority building programs that strengthen long-term visibility.</li>
+      </ul>
+      <a class="btn ghost" href="/HOME.HTML#contact">Discuss SEO Strategy</a>
+    </div>
+  </section>
+
+  <section class="section" id="content">
+    <div class="wrap detail">
+      <span class="pill">Content Marketing</span>
+      <h2>Build trust with purpose-built content systems</h2>
+      <p>Strategic storytelling transforms attention into action and keeps your pipeline warm between direct sales touchpoints.</p>
+      <ul>
+        <li>Audience research and positioning workshops that align your message.</li>
+        <li>Content playbooks that cover email, blog, video, and enablement assets.</li>
+        <li>Analytics dashboards so you can see what resonates and where to iterate.</li>
+      </ul>
+      <a class="btn ghost" href="/HOME.HTML#contact">Plan Your Editorial Roadmap</a>
+    </div>
+  </section>
+
+  <section class="section" id="social">
+    <div class="wrap detail">
+      <span class="pill">Social Media Strategy</span>
+      <h2>Grow an engaged community that converts</h2>
+      <p>We translate your brand voice into high-impact campaigns that drive consistent engagement and measurable pipeline.</p>
+      <ul>
+        <li>Channel-by-channel strategy with asset templates and governance.</li>
+        <li>Always-on monitoring and reporting for agility and responsiveness.</li>
+        <li>Influencer and partnership frameworks to expand your reach.</li>
+      </ul>
+      <a class="btn ghost" href="/HOME.HTML#contact">Start a Social Sprint</a>
+    </div>
+  </section>
+
+  <section class="section" id="paid">
+    <div class="wrap detail">
+      <span class="pill">Paid Ads (PPC)</span>
+      <h2>Turn ad spend into compounding revenue</h2>
+      <p>Performance campaigns engineered with clear KPIs, ongoing optimization, and transparency around every dollar invested.</p>
+      <ul>
+        <li>Funnel-aligned creative and landing pages for every audience segment.</li>
+        <li>Bid strategies tuned for efficiency, scale, and profitability.</li>
+        <li>Weekly experimentation cycles paired with automated reporting.</li>
+      </ul>
+      <a class="btn ghost" href="/HOME.HTML#contact">Optimize Paid Media</a>
+    </div>
+  </section>
+
+  <section class="section" id="crm">
+    <div class="wrap detail">
+      <span class="pill">CRM &amp; Automation</span>
+      <h2>Give your team a pipeline that runs on autopilot</h2>
+      <p>We implement the right CRM infrastructure, workflows, and automations so leads are nurtured 24/7 without manual effort.</p>
+      <ul>
+        <li>System architecture that unifies marketing, sales, and service data.</li>
+        <li>Automated nurture sequences using email, SMS, and task reminders.</li>
+        <li>Pipeline dashboards that surface priorities and revenue forecasts instantly.</li>
+      </ul>
+      <a class="btn ghost" href="/HOME.HTML#contact">Automate Your Revenue Engine</a>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>&copy; <span id="year"></span> Timeless Solutions. Every system we build saves your team time.</p>
+  </div>
+</footer>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated /services landing page that matches the HOME.HTML service cards
- provide detailed copy for each service section with consistent styling and anchors
- link navigation back to the main HOME page for context and contact CTAs

## Testing
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68cf03367750832b9d7fc8efdf641ffa