### PR TITLE
Add featured case study section to homepage

### DIFF
--- a/HOME.HTML
+++ b/HOME.HTML
@@ -144,6 +144,34 @@
     </div>
   </section>
 
+  <!-- CASE STUDY -->
+  <section class="section" id="case-study">
+    <div class="wrap">
+      <p class="muted">Featured Case Study</p>
+      <div class="row" style="gap:24px;margin-top:18px">
+        <div class="card">
+          <p class="muted">Client</p>
+          <h2>Atlas Realty</h2>
+          <p><strong>Industry:</strong> Residential Real Estate</p>
+          <p>Multi-market brokerage struggling to respond to inbound leads fast enough to win exclusive listings.</p>
+        </div>
+        <div class="card">
+          <h3>Problem</h3>
+          <p>Disjointed spreadsheets and manual texts created 48-hour average response times and inconsistent client experiences.</p>
+          <h3>Approach</h3>
+          <p>Implemented HubSpot CRM with automated lead routing, text/email sequences, and dashboards aligned to agent KPIs.</p>
+          <h3>Results</h3>
+          <div style="display:flex;flex-wrap:wrap;gap:12px;margin:8px 0 18px">
+            <span class="badge">-63% time-to-first-touch</span>
+            <span class="badge">+2.4 closings/mo</span>
+            <span class="badge">9.6/10 client CSAT</span>
+          </div>
+          <a class="btn primary" href="/case-studies/atlas-realty" style="margin-top:6px;display:inline-block">See the full case study</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ABOUT -->
   <section class="section" id="about">
     <div class="wrap row">


### PR DESCRIPTION
## Summary
- insert a featured case study section between the results and about blocks on the homepage
- outline the client, industry, problem, approach, results, and CTA using existing wrap/card styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf035715d8832ba7af03c41a902415