### PR TITLE
Ensure landing page served from index.html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -79,7 +79,8 @@
       </div>
       <div class="card" id="contact-form">
         <h2>Send us a message</h2>
-        <form action="https://formspree.io/f/your-id" method="POST">
+        <form action="https://formspree.io/f/xblanerj" method="POST">
+          <input type="hidden" name="_subject" value="Timeless Solutions Contact Page Inquiry">
           <div class="row" style="gap:16px">
             <div><label for="name" class="muted" style="display:block;margin-bottom:6px">Name</label><input id="name" name="name" placeholder="Full name" required></div>
             <div><label for="email" class="muted" style="display:block;margin-bottom:6px">Email</label><input id="email" name="email" type="email" placeholder="Email" required></div>

--- a/index.html
+++ b/index.html
@@ -176,7 +176,8 @@
     <div class="wrap">
       <div class="card">
         <h2>Contact</h2>
-        <form action="https://formspree.io/f/your-id" method="POST">
+        <form action="https://formspree.io/f/xblanerj" method="POST">
+          <input type="hidden" name="_subject" value="Timeless Solutions Website Inquiry">
           <div class="row" style="gap:16px">
             <input name="name" placeholder="Full name" required class="card" style="padding:12px">
             <input name="email" type="email" placeholder="Email" required class="card" style="padding:12px">

--- a/services/index.html
+++ b/services/index.html
@@ -48,12 +48,12 @@
 <header>
   <div class="wrap">
     <nav>
-      <a class="brand" href="/HOME.HTML">Timeless Solutions</a>
+      <a class="brand" href="/index.html">Timeless Solutions</a>
       <ul>
-        <li><a href="/HOME.HTML#services">Services Overview</a></li>
-        <li><a href="/HOME.HTML#results">Results</a></li>
-        <li><a href="/HOME.HTML#about">About</a></li>
-        <li><a class="btn primary" href="/HOME.HTML#contact">Book Strategy Call</a></li>
+        <li><a href="/index.html#services">Services Overview</a></li>
+        <li><a href="/index.html#results">Results</a></li>
+        <li><a href="/index.html#about">About</a></li>
+        <li><a class="btn primary" href="/index.html#contact">Book Strategy Call</a></li>
       </ul>
     </nav>
   </div>
@@ -85,7 +85,7 @@
         <li>Editorial calendars with search intent mapped to every stage of your funnel.</li>
         <li>Backlink and authority building programs that strengthen long-term visibility.</li>
       </ul>
-      <a class="btn ghost" href="/HOME.HTML#contact">Discuss SEO Strategy</a>
+      <a class="btn ghost" href="/index.html#contact">Discuss SEO Strategy</a>
     </div>
   </section>
 
@@ -99,7 +99,7 @@
         <li>Content playbooks that cover email, blog, video, and enablement assets.</li>
         <li>Analytics dashboards so you can see what resonates and where to iterate.</li>
       </ul>
-      <a class="btn ghost" href="/HOME.HTML#contact">Plan Your Editorial Roadmap</a>
+      <a class="btn ghost" href="/index.html#contact">Plan Your Editorial Roadmap</a>
     </div>
   </section>
 
@@ -113,7 +113,7 @@
         <li>Always-on monitoring and reporting for agility and responsiveness.</li>
         <li>Influencer and partnership frameworks to expand your reach.</li>
       </ul>
-      <a class="btn ghost" href="/HOME.HTML#contact">Start a Social Sprint</a>
+      <a class="btn ghost" href="/index.html#contact">Start a Social Sprint</a>
     </div>
   </section>
 
@@ -127,7 +127,7 @@
         <li>Bid strategies tuned for efficiency, scale, and profitability.</li>
         <li>Weekly experimentation cycles paired with automated reporting.</li>
       </ul>
-      <a class="btn ghost" href="/HOME.HTML#contact">Optimize Paid Media</a>
+      <a class="btn ghost" href="/index.html#contact">Optimize Paid Media</a>
     </div>
   </section>
 
@@ -141,7 +141,7 @@
         <li>Automated nurture sequences using email, SMS, and task reminders.</li>
         <li>Pipeline dashboards that surface priorities and revenue forecasts instantly.</li>
       </ul>
-      <a class="btn ghost" href="/HOME.HTML#contact">Automate Your Revenue Engine</a>
+      <a class="btn ghost" href="/index.html#contact">Automate Your Revenue Engine</a>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- update the landing page form to submit through Formspree with the required subject metadata
- point contact page form to the same Formspree endpoint to keep submissions consistent
- replace remaining `/HOME.HTML` navigation links with `/index.html` so the services page references the correct landing page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d499d10414832bb23e77c3b0a73e66