### PR TITLE
Switch marketing pages to premium dark theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,32 +9,40 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--black);background:var(--off);line-height:1.5}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--text);background:var(--background);line-height:1.5}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
+      border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
-    .btn.ghost{background:transparent;color:var(--black)}
-    .hero{padding:80px 0;background:#fff}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--text)}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
+      border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
-    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
+    .hero p{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:720px}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:32px}
     @media (max-width:900px){.row{grid-template-columns:1fr}}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:24px}
-    .section{padding:72px 0}
+    .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);
+      border-radius:var(--radius);padding:24px;box-shadow:var(--shadow)}
+    .section{padding:72px 0;border-top:1px solid rgba(244,245,248,.05)}
     h2{font-size:clamp(24px,3vw,36px);margin:0 0 8px}
     h3{margin:0 0 12px;font-size:20px}
-    .muted{color:#6C6C70}
-    .badge{display:inline-block;background:#fff;border:1px solid #eee;border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px}
-    footer{padding:48px 0;color:#444}
+    .muted{color:var(--muted)}
+    .badge{display:inline-block;background:rgba(200,165,69,.12);
+      border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
   </style>
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -9,33 +9,44 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--black);background:var(--off);line-height:1.5}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--text);background:var(--background);line-height:1.5}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
+      border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
-    .btn.ghost{background:transparent;color:var(--black)}
-    .hero{padding:80px 0;background:#fff}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--text)}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
+      border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
-    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
+    .hero p{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:720px}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:32px}
     @media (max-width:900px){.row{grid-template-columns:1fr}}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:24px}
-    .section{padding:72px 0}
+    .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);
+      border-radius:var(--radius);padding:24px;box-shadow:var(--shadow)}
+    .section{padding:72px 0;border-top:1px solid rgba(244,245,248,.05)}
     h2{font-size:clamp(24px,3vw,36px);margin:0 0 8px}
     h3{margin:0 0 12px;font-size:20px}
-    .muted{color:#6C6C70}
-    input, select, textarea{width:100%;border:1px solid #eee;border-radius:var(--radius);padding:12px;font-family:inherit;font-size:16px}
+    .muted{color:var(--muted)}
+    input, select, textarea{width:100%;border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);padding:12px;
+      font-family:inherit;font-size:16px;background:var(--surface);color:var(--text);transition:border-color .2s ease,box-shadow .2s ease}
+    input::placeholder, textarea::placeholder{color:var(--muted)}
+    input:focus, select:focus, textarea:focus{outline:none;border-color:var(--gold);
+      box-shadow:0 0 0 3px rgba(200,165,69,.24)}
     textarea{min-height:140px;resize:vertical}
-    footer{padding:48px 0;color:#444}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -9,36 +9,55 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
-    *{box-sizing:border-box} body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;
-      color:var(--black);background:var(--off);line-height:1.5}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--text);
+      background:var(--background);line-height:1.5}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);
+      backdrop-filter:blur(14px);border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
-    .btn.ghost{background:transparent;color:var(--black)}
-    .hero{padding:80px 0;background:#fff}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--text)}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
+      border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
-    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
+    .hero p{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:720px}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:32px}
     @media (max-width:900px){.row{grid-template-columns:1fr}}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:24px}
-    .section{padding:72px 0}
+    .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);
+      border-radius:var(--radius);padding:24px;box-shadow:var(--shadow)}
+    .section{padding:72px 0;border-top:1px solid rgba(244,245,248,.05)}
     h2{font-size:clamp(24px,3vw,36px);margin:0 0 8px}
-    .muted{color:#6C6C70}
+    .muted{color:var(--muted)}
     .grid{display:grid;gap:20px;grid-template-columns:repeat(5,1fr)}
     @media (max-width:1100px){.grid{grid-template-columns:repeat(3,1fr)}}
     @media (max-width:700px){.grid{grid-template-columns:repeat(1,1fr)}}
     .service h3{margin:8px 0 6px;font-size:18px}
-    .badge{display:inline-block;background:#fff;border:1px solid #eee;border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px}
-    .cta{background:var(--black);color:#fff;border-radius:var(--radius);padding:32px}
-    footer{padding:48px 0;color:#444}
+    .badge{display:inline-block;background:rgba(200,165,69,.12);
+      border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;
+      font-size:13px;color:var(--text)}
+    .cta{background:linear-gradient(135deg,rgba(200,165,69,.18) 0%,rgba(200,165,69,.05) 100%);
+      color:var(--text);border-radius:var(--radius);padding:32px;border:1px solid rgba(200,165,69,.4);
+      box-shadow:0 18px 40px rgba(200,165,69,.15)}
+    input,select,textarea{background:var(--surface);color:var(--text);border:1px solid rgba(244,245,248,.08);
+      border-radius:var(--radius);transition:border-color .2s ease,box-shadow .2s ease}
+    form .card{background:var(--surface);border:1px solid rgba(244,245,248,.08);
+      box-shadow:none;padding:12px}
+    input:focus,select:focus,textarea:focus{outline:none;border-color:var(--gold);
+      box-shadow:0 0 0 3px rgba(200,165,69,.24)}
+    input::placeholder,textarea::placeholder{color:var(--muted)}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
   </style>
 </head>
 <body>

--- a/services.html
+++ b/services.html
@@ -9,36 +9,44 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--black);background:var(--off);line-height:1.5}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;color:var(--text);background:var(--background);line-height:1.5}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
+      border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
-    .btn.ghost{background:transparent;color:var(--black)}
-    .hero{padding:80px 0;background:#fff}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--text)}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
+      border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
-    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
+    .hero p{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:720px}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:32px}
     @media (max-width:900px){.row{grid-template-columns:1fr}}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:24px}
-    .section{padding:72px 0}
+    .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);
+      border-radius:var(--radius);padding:24px;box-shadow:var(--shadow)}
+    .section{padding:72px 0;border-top:1px solid rgba(244,245,248,.05)}
     h2{font-size:clamp(24px,3vw,36px);margin:0 0 8px}
     h3{margin:0 0 12px;font-size:20px}
-    .muted{color:#6C6C70}
+    .muted{color:var(--muted)}
     .grid{display:grid;gap:20px;grid-template-columns:repeat(5,1fr)}
     @media (max-width:1100px){.grid{grid-template-columns:repeat(3,1fr)}}
     @media (max-width:700px){.grid{grid-template-columns:repeat(1,1fr)}}
     .service h3{margin:8px 0 6px;font-size:18px}
-    .badge{display:inline-block;background:#fff;border:1px solid #eee;border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px}
-    footer{padding:48px 0;color:#444}
+    .badge{display:inline-block;background:rgba(200,165,69,.12);
+      border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
   </style>
 </head>
 <body>

--- a/services/index.html
+++ b/services/index.html
@@ -8,35 +8,45 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
-    *{box-sizing:border-box} body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;
-      color:var(--black);background:var(--off);line-height:1.5}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial;
+      color:var(--text);background:var(--background);line-height:1.5}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
+      border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
-    .btn.ghost{background:transparent;color:var(--black)}
-    .hero{padding:80px 0;background:#fff}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn.ghost{background:transparent;color:var(--text)}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
+      border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
-    .hero p{font-size:clamp(16px,2vw,20px);color:#333;max-width:720px}
-    .section{padding:72px 0}
+    .hero p{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:720px}
+    .section{padding:72px 0;border-top:1px solid rgba(244,245,248,.05)}
     h2{font-size:clamp(24px,3vw,36px);margin:0 0 12px}
-    .muted{color:var(--gray)}
+    .muted{color:var(--muted)}
     .toc{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px}
-    .badge{display:inline-block;background:#fff;border:1px solid #eee;border-radius:999px;padding:10px 16px;font-size:14px}
-    .detail{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:32px;margin-bottom:28px}
+    .badge{display:inline-block;background:rgba(200,165,69,.12);
+      border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:10px 16px;font-size:14px;color:var(--text)}
+    .detail{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);
+      border-radius:var(--radius);padding:32px;margin-bottom:28px;box-shadow:var(--shadow)}
     .detail header{position:static;border:none;padding:0;margin-bottom:18px}
     .detail h3{margin:0 0 8px;font-size:22px}
     .detail ul{margin:0 0 18px 18px;padding:0}
     .detail ul li{margin-bottom:8px}
-    .pill{display:inline-block;background:var(--black);color:#fff;padding:8px 14px;border-radius:999px;font-size:13px;margin-bottom:16px}
-    footer{padding:48px 0;color:#444}
+    .pill{display:inline-block;background:var(--gold);color:var(--surface);padding:8px 14px;border-radius:999px;font-size:13px;margin-bottom:16px;
+      box-shadow:0 10px 24px rgba(200,165,69,.25)}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:700px){
       nav{flex-wrap:wrap;gap:12px;height:auto;padding:16px 0}
       nav ul{flex-wrap:wrap;justify-content:flex-end}


### PR DESCRIPTION
## Summary
- refresh the shared color tokens to use a deep background, charcoal surfaces, luminous gold accents, and soft neutral text across all marketing pages
- update body, header, hero, section, card, badge, and button styling for the new dark theme, including gradients, shadows, and CTA contrast adjustments
- refine form controls and utility elements so contact experiences remain legible in both desktop and mobile layouts

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4a9101f74832b97ac23717fcc0a9e