### PR TITLE
Add embedded booking and align privacy theme

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -46,6 +46,8 @@
     input:focus, select:focus, textarea:focus{outline:none;border-color:var(--gold);
       box-shadow:0 0 0 3px rgba(200,165,69,.24)}
     textarea{min-height:140px;resize:vertical}
+    .booking-frame{width:100%;height:600px;border:0;border-radius:var(--radius);background:var(--surface)}
+    .schedule-card{display:flex;flex-direction:column;gap:12px}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
   </style>
 </head>
@@ -72,6 +74,20 @@
       <div style="margin-top:18px;display:flex;gap:12px;flex-wrap:wrap;">
         <a class="btn primary" href="#contact-form">Start the form</a>
         <a class="btn ghost" href="mailto:hello@timelesssolutions.vip">Email us directly</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="schedule">
+    <div class="wrap">
+      <div class="card schedule-card">
+        <div>
+          <h2>Schedule an appointment</h2>
+          <p class="muted">Reserve a strategy session directly on our calendar—pick the time that works best for you.</p>
+        </div>
+        <!-- Google Calendar Appointment Scheduling begin -->
+        <iframe class="booking-frame" src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2uYryGejFTrG1EIaF0yw4kwi26X2AI7ecXmd6IKi3G-5BLBLdvuXWtpowxuwYf8o-lnR9FQZNl?gv=true" title="Timeless Solutions scheduling" loading="lazy"></iframe>
+        <!-- end Google Calendar Appointment Scheduling -->
       </div>
     </div>
   </section>

--- a/privacy.html
+++ b/privacy.html
@@ -8,27 +8,34 @@
   <link rel="icon" href="/favicon.png">
   <style>
     :root{
-      --black:#0B0B0C;--gold:#C8A545;--off:#F7F7F5;--gray:#6C6C70;
-      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px)
+      --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;
+      --text:#F4F5F8;--muted:#A0A1A8;--gold:#C8A545;
+      --radius:12px;--max:1120px;--space:clamp(16px,2vw,24px);
+      --shadow:0 24px 48px rgba(0,0,0,.45)
     }
     *{box-sizing:border-box}
-    body{margin:0;font-family:Inter,system-ui,"Segoe UI",Arial;color:var(--black);background:var(--off);line-height:1.6}
+    body{margin:0;font-family:Inter,system-ui,"Segoe UI",Arial;color:var(--text);background:var(--background);line-height:1.6}
     a{color:inherit;text-decoration:none}
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
-    header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;z-index:5}
+    header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
+      border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
     nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold)}
-    .btn.primary{background:var(--gold);color:#000;border-color:var(--gold);font-weight:600}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+      transition:transform .2s ease,box-shadow .2s ease}
+    .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
+    .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
     main{padding:80px 0}
     h1{font-size:clamp(32px,4vw,48px);margin:0 0 12px}
     h2{font-size:clamp(22px,3vw,30px);margin:36px 0 12px}
-    p{margin:0 0 16px;color:#333}
-    ul{margin:0 0 16px 20px;padding:0}
+    p{margin:0 0 16px;color:var(--text)}
+    p strong{color:var(--text)}
+    ul{margin:0 0 16px 20px;padding:0;color:var(--muted)}
     li{margin-bottom:10px}
-    .card{background:#fff;border:1px solid #eee;border-radius:var(--radius);padding:32px}
-    footer{padding:48px 0;color:#444}
+    .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);border-radius:var(--radius);
+      padding:32px;box-shadow:var(--shadow)}
+    footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:700px){
       nav{flex-wrap:wrap;gap:12px;height:auto;padding:16px 0}
       nav ul{flex-wrap:wrap;justify-content:flex-end}


### PR DESCRIPTION
## Summary
- embed the Google Calendar scheduling iframe on the contact page with supportive styling and copy
- extend the contact page styles to support the new booking card in the dark theme system
- restyle the privacy policy to match the dark theme palette used across the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a7ae0334832bb350410af111e289