### PR TITLE
Add scroll-triggered fade-in animations

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,6 +28,11 @@
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
       border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
@@ -61,7 +66,7 @@
 </header>
 
 <main>
-  <section class="hero">
+  <section class="hero" data-animate>
     <div class="wrap">
       <h1>About Timeless Solutions</h1>
       <p>We build marketing and CRM systems that respect your time. Our team blends strategy, creativity, and automation so every lead is nurtured from first touch to closed deal.</p>
@@ -72,7 +77,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Our Story</h2>
@@ -90,7 +95,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Values We Operate By</h2>
@@ -109,14 +114,14 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap card">
       <h2>Our Promise</h2>
       <p>We partner closely, stay proactive with communication, and act like an extension of your in-house team. Every engagement includes clear roadmaps, documented processes, and the insights you need to scale with confidence.</p>
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap" style="display:flex;flex-direction:column;align-items:flex-start;gap:16px;">
       <h2>Let’s work together</h2>
       <p class="muted">Tell us where you’re losing time and we’ll design a system that gives it back.</p>
@@ -130,7 +135,30 @@
     <div>© <span id="y"></span> Timeless Solutions</div>
     <div><a href="privacy.html">Privacy</a></div>
   </div>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('y').textContent=new Date().getFullYear();
+    document.addEventListener('DOMContentLoaded',()=>{
+      document.body.classList.add('ready');
+      const elements=document.querySelectorAll('[data-animate]');
+      if(!('IntersectionObserver'in window)){
+        elements.forEach(el=>el.classList.add('in-view'));
+        return;
+      }
+      const observer=new IntersectionObserver((entries)=>{
+        entries.forEach(entry=>{
+          if(entry.isIntersecting){
+            entry.target.classList.add('in-view');
+            observer.unobserve(entry.target);
+          }
+        });
+      },{threshold:.15,rootMargin:'0px 0px -80px'});
+      elements.forEach((el,index)=>{
+        const delay=el.dataset.animateDelay?Number(el.dataset.animateDelay):Math.min(index*.08,.6);
+        el.style.transitionDelay=`${delay}s`;
+        observer.observe(el);
+      });
+    });
+  </script>
 </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -28,6 +28,11 @@
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
       border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
@@ -67,7 +72,7 @@
 </header>
 
 <main>
-  <section class="hero">
+  <section class="hero" data-animate>
     <div class="wrap">
       <h1>Let’s Plan Your Next Quarter</h1>
       <p>Share a few details about your goals and we’ll follow up with a tailored plan, timeline, and pricing options within one business day.</p>
@@ -78,7 +83,7 @@
     </div>
   </section>
 
-  <section class="section" id="schedule">
+  <section class="section" id="schedule" data-animate>
     <div class="wrap">
       <div class="card schedule-card">
         <div>
@@ -92,7 +97,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>How to reach us</h2>
@@ -133,7 +138,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap card">
       <h2>What happens next?</h2>
       <ol>
@@ -150,7 +155,30 @@
     <div>© <span id="y"></span> Timeless Solutions</div>
     <div><a href="privacy.html">Privacy</a></div>
   </div>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('y').textContent=new Date().getFullYear();
+    document.addEventListener('DOMContentLoaded',()=>{
+      document.body.classList.add('ready');
+      const elements=document.querySelectorAll('[data-animate]');
+      if(!('IntersectionObserver'in window)){
+        elements.forEach(el=>el.classList.add('in-view'));
+        return;
+      }
+      const observer=new IntersectionObserver((entries)=>{
+        entries.forEach(entry=>{
+          if(entry.isIntersecting){
+            entry.target.classList.add('in-view');
+            observer.unobserve(entry.target);
+          }
+        });
+      },{threshold:.15,rootMargin:'0px 0px -80px'});
+      elements.forEach((el,index)=>{
+        const delay=el.dataset.animateDelay?Number(el.dataset.animateDelay):Math.min(index*.08,.6);
+        el.style.transitionDelay=`${delay}s`;
+        observer.observe(el);
+      });
+    });
+  </script>
 </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
       border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
@@ -77,7 +82,7 @@
 
 <main>
   <!-- HERO -->
-  <section class="hero">
+  <section class="hero" data-animate>
     <div class="wrap">
       <h1>Time-Saving Marketing & CRM Systems</h1>
       <p>We build data-driven strategy, content, and automations so you stop losing time (and leads) and start scaling with clarity.</p>
@@ -89,7 +94,7 @@
   </section>
 
   <!-- PAIN / SOLUTION -->
-  <section class="section" id="how">
+  <section class="section" id="how" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Stuck in Busywork?</h2>
@@ -114,7 +119,7 @@
   </section>
 
   <!-- SERVICES GRID -->
-  <section class="section" id="services">
+  <section class="section" id="services" data-animate>
     <div class="wrap">
       <h2>Our Core Services</h2>
       <p class="muted">Designed to be intentional, repeatable, and timeless.</p>
@@ -149,7 +154,7 @@
   </section>
 
   <!-- RESULTS -->
-  <section class="section" id="results">
+  <section class="section" id="results" data-animate>
     <div class="wrap">
       <div class="card">
         <h2>Proven Results</h2>
@@ -164,7 +169,7 @@
   </section>
 
   <!-- ABOUT -->
-  <section class="section" id="about">
+  <section class="section" id="about" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>About Timeless Solutions</h2>
@@ -182,7 +187,7 @@
   </section>
 
   <!-- FINAL CTA -->
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap cta">
       <h2>Ready to save time and scale?</h2>
       <p>Book a free strategy call. We’ll map your quickest path to organized growth.</p>
@@ -191,7 +196,7 @@
   </section>
 
   <!-- CONTACT -->
-  <section class="section" id="contact">
+  <section class="section" id="contact" data-animate>
     <div class="wrap">
       <div class="card">
         <h2>Contact</h2>
@@ -221,7 +226,30 @@
     <div>© <span id="y"></span> Timeless Solutions</div>
     <div><a href="privacy.html">Privacy</a></div>
   </div>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('y').textContent=new Date().getFullYear();
+    document.addEventListener('DOMContentLoaded',()=>{
+      document.body.classList.add('ready');
+      const elements=document.querySelectorAll('[data-animate]');
+      if(!('IntersectionObserver'in window)){
+        elements.forEach(el=>el.classList.add('in-view'));
+        return;
+      }
+      const observer=new IntersectionObserver((entries)=>{
+        entries.forEach(entry=>{
+          if(entry.isIntersecting){
+            entry.target.classList.add('in-view');
+            observer.unobserve(entry.target);
+          }
+        });
+      },{threshold:.15,rootMargin:'0px 0px -80px'});
+      elements.forEach((el,index)=>{
+        const delay=el.dataset.animateDelay?Number(el.dataset.animateDelay):Math.min(index*.08,.6);
+        el.style.transitionDelay=`${delay}s`;
+        observer.observe(el);
+      });
+    });
+  </script>
 </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -26,6 +26,11 @@
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     main{padding:80px 0}
     h1{font-size:clamp(32px,4vw,48px);margin:0 0 12px}
     h2{font-size:clamp(22px,3vw,30px);margin:36px 0 12px}
@@ -61,7 +66,7 @@
 
 <main>
   <div class="wrap">
-    <div class="card">
+    <div class="card" data-animate>
       <h1>Privacy Policy</h1>
       <p>Effective date: <strong><span id="effective-year"></span></strong></p>
       <p>Timeless Solutions ("we," "us," or "our") respects your privacy and is committed to protecting any personal information you share with us. This policy explains what data we collect, why we collect it, how we use it, and the choices you have about your information.</p>
@@ -123,6 +128,27 @@
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();
   document.getElementById('effective-year').textContent = new Date().getFullYear();
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('ready');
+    const elements = document.querySelectorAll('[data-animate]');
+    if (!('IntersectionObserver' in window)) {
+      elements.forEach(el => el.classList.add('in-view'));
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in-view');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: .15, rootMargin: '0px 0px -80px' });
+    elements.forEach((el, index) => {
+      const delay = el.dataset.animateDelay ? Number(el.dataset.animateDelay) : Math.min(index * .08, .6);
+      el.style.transitionDelay = `${delay}s`;
+      observer.observe(el);
+    });
+  });
 </script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -28,6 +28,11 @@
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
       border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
@@ -65,7 +70,7 @@
 </header>
 
 <main>
-  <section class="hero">
+  <section class="hero" data-animate>
     <div class="wrap">
       <h1>Services Built to Save Your Time</h1>
       <p>Every engagement pairs strategy, systems, and execution so your team can focus on relationships while the pipeline keeps moving.</p>
@@ -76,7 +81,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap">
       <h2>How We Partner</h2>
       <p class="muted">Choose a service below to see the specific problems we solve, what we deliver, and the KPIs we own.</p>
@@ -110,7 +115,7 @@
     </div>
   </section>
 
-  <section class="section" id="seo">
+  <section class="section" id="seo" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>SEO Optimization</h2>
@@ -130,7 +135,7 @@
     </div>
   </section>
 
-  <section class="section" id="content">
+  <section class="section" id="content" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Content Marketing</h2>
@@ -150,7 +155,7 @@
     </div>
   </section>
 
-  <section class="section" id="social">
+  <section class="section" id="social" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Social Media Strategy</h2>
@@ -170,7 +175,7 @@
     </div>
   </section>
 
-  <section class="section" id="paid">
+  <section class="section" id="paid" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>Paid Ads (PPC)</h2>
@@ -190,7 +195,7 @@
     </div>
   </section>
 
-  <section class="section" id="crm">
+  <section class="section" id="crm" data-animate>
     <div class="wrap row">
       <div class="card">
         <h2>CRM &amp; Automation</h2>
@@ -210,7 +215,7 @@
     </div>
   </section>
 
-  <section class="section">
+  <section class="section" data-animate>
     <div class="wrap" style="display:flex;flex-direction:column;align-items:flex-start;gap:16px;">
       <h2>Ready to scope your project?</h2>
       <p class="muted">Share your goals and we’ll map the fastest path to organized growth.</p>
@@ -224,7 +229,30 @@
     <div>© <span id="y"></span> Timeless Solutions</div>
     <div><a href="privacy.html">Privacy</a></div>
   </div>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script>
+    document.getElementById('y').textContent=new Date().getFullYear();
+    document.addEventListener('DOMContentLoaded',()=>{
+      document.body.classList.add('ready');
+      const elements=document.querySelectorAll('[data-animate]');
+      if(!('IntersectionObserver'in window)){
+        elements.forEach(el=>el.classList.add('in-view'));
+        return;
+      }
+      const observer=new IntersectionObserver((entries)=>{
+        entries.forEach(entry=>{
+          if(entry.isIntersecting){
+            entry.target.classList.add('in-view');
+            observer.unobserve(entry.target);
+          }
+        });
+      },{threshold:.15,rootMargin:'0px 0px -80px'});
+      elements.forEach((el,index)=>{
+        const delay=el.dataset.animateDelay?Number(el.dataset.animateDelay):Math.min(index*.08,.6);
+        el.style.transitionDelay=`${delay}s`;
+        observer.observe(el);
+      });
+    });
+  </script>
 </footer>
 </body>
 </html>

--- a/services/index.html
+++ b/services/index.html
@@ -28,6 +28,11 @@
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
+    body.ready [data-animate]{opacity:0;transform:translateY(28px);transition:opacity .9s ease,transform .9s ease}
+    body.ready [data-animate].in-view{opacity:1;transform:translateY(0)}
+    @media (prefers-reduced-motion:reduce){
+      body.ready [data-animate]{opacity:1 !important;transform:none !important;transition:none !important}
+    }
     .hero{padding:80px 0;background:linear-gradient(135deg,var(--surface) 0%,#1F1F27 100%);
       border-bottom:1px solid rgba(244,245,248,.06)}
     .hero h1{font-size:clamp(32px,4.5vw,56px);margin:0 0 12px}
@@ -70,7 +75,7 @@
 </header>
 
 <main>
-  <section class="hero">
+  <section class="hero" data-animate>
     <div class="wrap">
       <p class="muted">Services</p>
       <h1>Strategic Systems Built Around Your Growth</h1>
@@ -85,7 +90,7 @@
     </div>
   </section>
 
-  <section class="section" id="seo">
+  <section class="section" id="seo" data-animate>
     <div class="wrap detail">
       <span class="pill">SEO Optimization</span>
       <h2>Show up exactly where your buyers are searching</h2>
@@ -99,7 +104,7 @@
     </div>
   </section>
 
-  <section class="section" id="content">
+  <section class="section" id="content" data-animate>
     <div class="wrap detail">
       <span class="pill">Content Marketing</span>
       <h2>Build trust with purpose-built content systems</h2>
@@ -113,7 +118,7 @@
     </div>
   </section>
 
-  <section class="section" id="social">
+  <section class="section" id="social" data-animate>
     <div class="wrap detail">
       <span class="pill">Social Media Strategy</span>
       <h2>Grow an engaged community that converts</h2>
@@ -127,7 +132,7 @@
     </div>
   </section>
 
-  <section class="section" id="paid">
+  <section class="section" id="paid" data-animate>
     <div class="wrap detail">
       <span class="pill">Paid Ads (PPC)</span>
       <h2>Turn ad spend into compounding revenue</h2>
@@ -141,7 +146,7 @@
     </div>
   </section>
 
-  <section class="section" id="crm">
+  <section class="section" id="crm" data-animate>
     <div class="wrap detail">
       <span class="pill">CRM &amp; Automation</span>
       <h2>Give your team a pipeline that runs on autopilot</h2>
@@ -163,6 +168,27 @@
 </footer>
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('ready');
+    const elements = document.querySelectorAll('[data-animate]');
+    if (!('IntersectionObserver' in window)) {
+      elements.forEach(el => el.classList.add('in-view'));
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in-view');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: .15, rootMargin: '0px 0px -80px' });
+    elements.forEach((el, index) => {
+      const delay = el.dataset.animateDelay ? Number(el.dataset.animateDelay) : Math.min(index * .08, .6);
+      el.style.transitionDelay = `${delay}s`;
+      observer.observe(el);
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable scroll-triggered fade-in animation styles with a reduced-motion fallback across the marketing pages
- mark hero and section blocks for animation and initialize an IntersectionObserver to reveal them smoothly as visitors scroll

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d4b2a35ffc832bbaeb7244176c61c4