### PR TITLE
Improve mobile header layout and CTA alignment

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,8 +22,8 @@
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
@@ -48,6 +48,12 @@
     .badge{display:inline-block;background:rgba(200,165,69,.12);
       border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
+    }
   </style>
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -22,8 +22,8 @@
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
@@ -54,6 +54,12 @@
     .booking-frame{width:100%;height:600px;border:0;border-radius:var(--radius);background:var(--surface)}
     .schedule-card{display:flex;flex-direction:column;gap:12px}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
+    }
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
       backdrop-filter:blur(14px);border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
@@ -63,6 +63,14 @@
       box-shadow:0 0 0 3px rgba(200,165,69,.24)}
     input::placeholder,textarea::placeholder{color:var(--muted)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
+      .cta{text-align:center}
+      .cta .btn{width:100%}
+    }
   </style>
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -21,8 +21,8 @@
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn:hover{transform:translateY(-2px);box-shadow:0 12px 24px rgba(200,165,69,.3)}
@@ -41,9 +41,11 @@
     .card{background:var(--surface-raised);border:1px solid rgba(244,245,248,.05);border-radius:var(--radius);
       padding:32px;box-shadow:var(--shadow)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
-    @media (max-width:700px){
-      nav{flex-wrap:wrap;gap:12px;height:auto;padding:16px 0}
-      nav ul{flex-wrap:wrap;justify-content:flex-end}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
       main{padding:60px 0}
       .card{padding:24px}
     }

--- a/services.html
+++ b/services.html
@@ -22,8 +22,8 @@
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
@@ -52,6 +52,14 @@
     .badge{display:inline-block;background:rgba(200,165,69,.12);
       border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
+      .cta{text-align:center}
+      .cta .btn{width:100%}
+    }
   </style>
 </head>
 <body>

--- a/services/index.html
+++ b/services/index.html
@@ -22,8 +22,8 @@
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
     nav{display:flex;align-items:center;justify-content:space-between;height:64px}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0}
-    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);
+    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
     .btn.ghost{background:transparent;color:var(--text)}
@@ -52,9 +52,11 @@
     .pill{display:inline-block;background:var(--gold);color:var(--surface);padding:8px 14px;border-radius:999px;font-size:13px;margin-bottom:16px;
       box-shadow:0 10px 24px rgba(200,165,69,.25)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
-    @media (max-width:700px){
-      nav{flex-wrap:wrap;gap:12px;height:auto;padding:16px 0}
-      nav ul{flex-wrap:wrap;justify-content:flex-end}
+    @media (max-width:640px){
+      nav{flex-direction:column;align-items:stretch;height:auto;padding:12px 0;gap:12px}
+      nav ul{flex-direction:column;gap:12px}
+      nav ul a{display:block;width:100%}
+      nav ul .btn{width:100%}
       .hero{padding:60px 0}
     }
   </style>


### PR DESCRIPTION
## Summary
- allow navigation lists to wrap and stack on small screens so the sticky header is no longer clipped on mobile
- center the "Book Strategy Call" button text and stretch it full width on phones for consistent alignment
- apply the responsive navigation tweaks across all pages to keep the mobile header consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b6c37bb8832b95b43f6444d96d55