### PR TITLE
Adjust header spacing on desktop

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,9 +20,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -72,11 +73,12 @@
       border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}

--- a/contact.html
+++ b/contact.html
@@ -20,9 +20,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -78,11 +79,12 @@
     .schedule-card{display:flex;flex-direction:column;gap:12px}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}

--- a/index.html
+++ b/index.html
@@ -21,9 +21,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);
       backdrop-filter:blur(14px);border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -87,11 +88,12 @@
     input::placeholder,textarea::placeholder{color:var(--muted)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}

--- a/privacy.html
+++ b/privacy.html
@@ -19,9 +19,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -65,11 +66,12 @@
       padding:32px;box-shadow:var(--shadow)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}

--- a/services.html
+++ b/services.html
@@ -20,9 +20,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -76,11 +77,12 @@
       border:1px solid rgba(200,165,69,.4);border-radius:999px;padding:6px 10px;margin:6px 6px 0 0;font-size:13px;color:var(--text)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}

--- a/services/index.html
+++ b/services/index.html
@@ -20,9 +20,10 @@
     .wrap{max-width:var(--max);margin:auto;padding:0 var(--space)}
     header{position:sticky;top:0;background:rgba(11,11,12,.95);backdrop-filter:blur(14px);
       border-bottom:1px solid rgba(244,245,248,.06);z-index:5}
-    nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative}
+    nav{display:flex;align-items:center;justify-content:space-between;gap:32px;padding:18px 0;position:relative}
     nav .brand{font-weight:700;letter-spacing:.3px}
-    nav ul{display:flex;gap:20px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul{display:flex;align-items:center;gap:28px;list-style:none;margin:0;padding:0;flex-wrap:wrap}
+    nav ul li:last-child{margin-left:12px}
     .btn{display:inline-block;padding:12px 18px;border-radius:999px;border:1px solid var(--gold);text-align:center;
       transition:transform .2s ease,box-shadow .2s ease}
     .btn.primary{background:var(--gold);color:var(--surface);border-color:var(--gold);font-weight:600}
@@ -76,11 +77,12 @@
       box-shadow:0 10px 24px rgba(200,165,69,.25)}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
-      nav{height:64px;padding:0}
+      nav{height:64px;padding:0;gap:0}
       nav .menu-toggle{display:flex;align-items:center;justify-content:center}
       nav ul{display:none;position:absolute;top:64px;left:0;right:0;background:rgba(20,20,24,.97);
         border:1px solid rgba(244,245,248,.08);border-radius:var(--radius);flex-direction:column;gap:16px;padding:20px;
         box-shadow:var(--shadow);z-index:10}
+      nav ul li:last-child{margin-left:0}
       nav.menu-open ul{display:flex}
       nav ul a{display:block;width:100%}
       nav ul .btn{width:100%}


### PR DESCRIPTION
## Summary
- increase the desktop navigation padding and spacing so the sticky header has more breathing room
- keep the mobile menu layout unchanged by overriding the CTA margin inside the small-screen breakpoint

## Testing
- no automated tests were run (static HTML site)


------
https://chatgpt.com/codex/tasks/task_e_68d4beeb2014832b8c5ec5797180ae1a