### PR TITLE
Adjust schedule card styling for embedded calendar

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -75,8 +75,10 @@
     input:focus, select:focus, textarea:focus{outline:none;border-color:var(--gold);
       box-shadow:0 0 0 3px rgba(200,165,69,.24)}
     textarea{min-height:140px;resize:vertical}
-    .booking-frame{width:100%;height:600px;border:0;border-radius:var(--radius);background:var(--surface)}
-    .schedule-card{display:flex;flex-direction:column;gap:12px}
+    .booking-frame{width:100%;height:600px;border:0;border-radius:var(--radius);background:#fff;box-shadow:inset 0 0 0 1px rgba(11,11,12,.08)}
+    .schedule-card{display:flex;flex-direction:column;gap:12px;background:#F4F5F8;color:#0B0B0C;border:1px solid rgba(11,11,12,.08)}
+    .schedule-card h2{color:#0B0B0C}
+    .schedule-card .muted{color:#3C3F4A}
     footer{padding:48px 0;color:var(--muted);border-top:1px solid rgba(244,245,248,.05)}
     @media (max-width:640px){
       nav{height:64px;padding:0;gap:0}


### PR DESCRIPTION
## Summary
- lighten the embedded scheduling card background to improve contrast for the Google calendar iframe
- ensure accompanying heading and helper text render with dark text on the new light surface
- give the iframe a white backdrop and subtle border to keep the embed legible against the page

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5a3d10f50832b92b9cb04fe4728e8