### PR TITLE
Add canonical tag to services index page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -5,6 +5,7 @@
   <title>Timeless Solutions | Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
+  <link rel="canonical" href="https://timelesssolutions.vip/services">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{


### PR DESCRIPTION
## Summary
- add a self-referencing canonical link tag to the services index page head to match the primary URL

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5acf07da0832bbad6b373b74113b0