### PR TITLE
Add social sharing metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Learn about Timeless Solutions, our founders, and the values guiding our marketing and automation work.">
   <link rel="canonical" href="https://timelesssolutions.vip/about">
+  <meta property="og:title" content="Timeless Solutions | About">
+  <meta property="og:description" content="Learn about Timeless Solutions, our founders, and the values guiding our marketing and automation work.">
+  <meta property="og:url" content="https://timelesssolutions.vip/about">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | About">
+  <meta name="twitter:description" content="Learn about Timeless Solutions, our founders, and the values guiding our marketing and automation work.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
   <link rel="canonical" href="https://timelesssolutions.vip/contact">
+  <meta property="og:title" content="Timeless Solutions | Contact">
+  <meta property="og:description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
+  <meta property="og:url" content="https://timelesssolutions.vip/contact">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | Contact">
+  <meta name="twitter:description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Timeless Solutions builds data-driven marketing, CRM setup, and automations that turn leads into clients while saving you time.">
   <link rel="canonical" href="https://timelesssolutions.vip/">
+  <meta property="og:title" content="Timeless Solutions | Time-Saving Digital Marketing &amp; CRM">
+  <meta property="og:description" content="Timeless Solutions builds data-driven marketing, CRM setup, and automations that turn leads into clients while saving you time.">
+  <meta property="og:url" content="https://timelesssolutions.vip/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | Time-Saving Digital Marketing &amp; CRM">
+  <meta name="twitter:description" content="Timeless Solutions builds data-driven marketing, CRM setup, and automations that turn leads into clients while saving you time.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,15 @@
   <title>Timeless Solutions | Privacy Policy</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Privacy policy detailing how Timeless Solutions collects, uses, and protects visitor information.">
+  <meta property="og:title" content="Timeless Solutions | Privacy Policy">
+  <meta property="og:description" content="Privacy policy detailing how Timeless Solutions collects, uses, and protects visitor information.">
+  <meta property="og:url" content="https://timelesssolutions.vip/privacy">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | Privacy Policy">
+  <meta name="twitter:description" content="Privacy policy detailing how Timeless Solutions collects, uses, and protects visitor information.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{

--- a/services.html
+++ b/services.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Explore the digital marketing, automation, and CRM services offered by Timeless Solutions.">
   <link rel="canonical" href="https://timelesssolutions.vip/services">
+  <meta property="og:title" content="Timeless Solutions | Services">
+  <meta property="og:description" content="Explore the digital marketing, automation, and CRM services offered by Timeless Solutions.">
+  <meta property="og:url" content="https://timelesssolutions.vip/services">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | Services">
+  <meta name="twitter:description" content="Explore the digital marketing, automation, and CRM services offered by Timeless Solutions.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{

--- a/services/index.html
+++ b/services/index.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
   <link rel="canonical" href="https://timelesssolutions.vip/services">
+  <meta property="og:title" content="Timeless Solutions | Services">
+  <meta property="og:description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
+  <meta property="og:url" content="https://timelesssolutions.vip/services">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Timeless Solutions | Services">
+  <meta name="twitter:description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
+  <meta name="twitter:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
   <link rel="icon" href="/favicon.png">
   <style>
     :root{


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter Card metadata to every public marketing page
- reuse existing copy and canonical URLs while pointing to a shared social preview image

## Testing
- not run (validation with external sharing debuggers requires network access)


------
https://chatgpt.com/codex/tasks/task_e_68d5ad670f64832bb75c45fe7362a0c8