### PR TITLE
Add JSON-LD schema to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,32 @@
   <meta name="description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
   <link rel="canonical" href="https://timelesssolutions.vip/contact">
   <link rel="icon" href="/favicon.png">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Timeless Solutions",
+      "url": "https://timelesssolutions.vip",
+      "email": "hello@timelesssolutions.vip",
+      "telephone": null,
+      "sameAs": [
+        "https://calendly.com/timelesssolutions/strategy-call"
+      ],
+      "openingHoursSpecification": {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday"
+        ],
+        "opens": "09:00",
+        "closes": "17:00",
+        "timeZone": "America/Chicago"
+      }
+    }
+  </script>
   <style>
     :root{
       --background:#0B0B0C;--surface:#141418;--surface-raised:#1C1C23;


### PR DESCRIPTION
## Summary
- add an Organization JSON-LD block to the contact page with contact details and office hours

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b2610ec0832bac3d9aee1364d919