### PR TITLE
Add canonical link to privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -10,6 +10,7 @@
   <meta property="og:url" content="https://timelesssolutions.vip/privacy">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://timelesssolutions.vip/assets/og-default.jpg">
+  <link rel="canonical" href="https://timelesssolutions.vip/privacy/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Timeless Solutions | Privacy Policy">
   <meta name="twitter:description" content="Privacy policy detailing how Timeless Solutions collects, uses, and protects visitor information.">


### PR DESCRIPTION
## Summary
- add a canonical link element to the privacy page that matches the site's URL conventions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6d1c464a4832b91b66d993916e593