### PR TITLE
Add trailing slashes to canonical URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <title>Timeless Solutions | About</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Learn about Timeless Solutions, our founders, and the values guiding our marketing and automation work.">
-  <link rel="canonical" href="https://timelesssolutions.vip/about">
+  <link rel="canonical" href="https://timelesssolutions.vip/about/">
   <meta property="og:title" content="Timeless Solutions | About">
   <meta property="og:description" content="Learn about Timeless Solutions, our founders, and the values guiding our marketing and automation work.">
   <meta property="og:url" content="https://timelesssolutions.vip/about">

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <title>Timeless Solutions | Contact</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
-  <link rel="canonical" href="https://timelesssolutions.vip/contact">
+  <link rel="canonical" href="https://timelesssolutions.vip/contact/">
   <meta property="og:title" content="Timeless Solutions | Contact">
   <meta property="og:description" content="Connect with Timeless Solutions to book a strategy call or request a project estimate.">
   <meta property="og:url" content="https://timelesssolutions.vip/contact">

--- a/services.html
+++ b/services.html
@@ -5,7 +5,7 @@
   <title>Timeless Solutions | Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Explore the digital marketing, automation, and CRM services offered by Timeless Solutions.">
-  <link rel="canonical" href="https://timelesssolutions.vip/services">
+  <link rel="canonical" href="https://timelesssolutions.vip/services/">
   <meta property="og:title" content="Timeless Solutions | Services">
   <meta property="og:description" content="Explore the digital marketing, automation, and CRM services offered by Timeless Solutions.">
   <meta property="og:url" content="https://timelesssolutions.vip/services">

--- a/services/index.html
+++ b/services/index.html
@@ -5,7 +5,7 @@
   <title>Timeless Solutions | Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
-  <link rel="canonical" href="https://timelesssolutions.vip/services">
+  <link rel="canonical" href="https://timelesssolutions.vip/services/">
   <meta property="og:title" content="Timeless Solutions | Services">
   <meta property="og:description" content="Explore the core marketing, content, social, paid ads, and CRM services offered by Timeless Solutions.">
   <meta property="og:url" content="https://timelesssolutions.vip/services">


### PR DESCRIPTION
## Summary
- ensure canonical links on about, services, and contact pages use trailing slash URLs
- align the services section index page canonical URL with the trailing slash format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d1b836b0832b9a3e365148c538a5